### PR TITLE
Update deploy workflow to run when Test is completed and run only development and master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,15 @@
 name: Deploy
 
-on: push
+on:
+  workflow_run:
+    workflows:
+      - Test
+    branches:
+      - master
+      - development
+    types:
+      - completed
+  workflow_dispatch:
 
 env:
   DOCKER_IMAGE: ${{ github.repository }}
@@ -15,9 +24,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Branch Tag
         uses: nimblehq/branch-tag-action@v1.2
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Set HEROKU_APP
         run: |


### PR DESCRIPTION
## What happened
- Run deploy workflow when `Test` workflow is completed
- Run deploy workflow only on `development` and `master` branch

## Insight
This chore can be tested after merge to default (which is development) or master branch as `workflow_run` event must exist on the master or default branch. And this workflow will only run on the master or default branch [(ref)](https://github.community/t/workflow-runs-not-starting-after-previous-workflow-completes/128345/7)

## Proof Of Work
- Deploy workflow must run when `Test` is completed on development branch.
