### PR TITLE
As a user, I can fetch keyword result via API

### DIFF
--- a/controllers/api_v1/keyword.go
+++ b/controllers/api_v1/keyword.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gutakk/go-google-scraper/helpers/api_helper"
+	errorHelpers "github.com/gutakk/go-google-scraper/helpers/error_handler"
 	helpers "github.com/gutakk/go-google-scraper/helpers/user"
 	"github.com/gutakk/go-google-scraper/serializers"
 	"github.com/gutakk/go-google-scraper/services/keyword_service"
@@ -31,9 +32,16 @@ func (kapi *KeywordAPIController) fetchKeyword(c *gin.Context) {
 
 	keyword, err := keywordService.GetKeywordResult(keywordID)
 	if err != nil {
+		var status int
+		if err.Error() == errorHelpers.KeywordNotFoundError {
+			status = http.StatusNotFound
+		} else {
+			status = http.StatusBadRequest
+		}
+
 		errorResponse := api_helper.ErrorResponseObject{
 			Detail: err.Error(),
-			Status: http.StatusBadRequest,
+			Status: status,
 		}
 		c.JSON(errorResponse.Status, errorResponse.NewErrorResponse())
 		return

--- a/controllers/api_v1/keyword.go
+++ b/controllers/api_v1/keyword.go
@@ -19,8 +19,27 @@ const (
 type KeywordAPIController struct{}
 
 func (kapi *KeywordAPIController) ApplyRoutes(engine *gin.RouterGroup) {
+	engine.GET("/keywords/:keyword_id", kapi.fetchKeyword)
 	engine.GET("/keywords", kapi.fetchKeywords)
 	engine.POST("/keywords", kapi.uploadKeyword)
+}
+
+func (kapi *KeywordAPIController) fetchKeyword(c *gin.Context) {
+	currentUserID := helpers.GetCurrentUserID(c)
+	keywordService := keyword_service.KeywordService{CurrentUserID: currentUserID}
+	keywordID := c.Param("keyword_id")
+
+	keyword, err := keywordService.GetKeywordResult(keywordID)
+	if err != nil {
+		errorResponse := api_helper.ErrorResponseObject{
+			Detail: err.Error(),
+			Status: http.StatusBadRequest,
+		}
+		c.JSON(errorResponse.Status, errorResponse.NewErrorResponse())
+		return
+	}
+
+	c.JSON(http.StatusOK, keyword_api_service.JSONAPIFormatKeywordResponse(keyword))
 }
 
 func (kapi *KeywordAPIController) fetchKeywords(c *gin.Context) {

--- a/controllers/api_v1/keyword.go
+++ b/controllers/api_v1/keyword.go
@@ -47,7 +47,9 @@ func (kapi *KeywordAPIController) fetchKeyword(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, keyword_api_service.JSONAPIFormatKeywordResponse(keyword))
+	keywordSerializer := serializers.KeywordSerializer{Keyword: keyword}
+
+	c.JSON(http.StatusOK, keywordSerializer.JSONAPIFormat())
 }
 
 func (kapi *KeywordAPIController) fetchKeywords(c *gin.Context) {

--- a/controllers/api_v1/keyword_test.go
+++ b/controllers/api_v1/keyword_test.go
@@ -160,9 +160,12 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordWithValidParams() {
 		`"status":"pending",` +
 		`"links_count":1,` +
 		`"non_adwords_count":1,` +
+		`"non_adword_links":null,` +
 		`"top_position_adwords_count":1,` +
+		`"top_position_adword_links":null,` +
 		`"total_adwords_count":1,` +
-		`"html_code":"testHTML"` +
+		`"html_code":"testHTML",` +
+		`"failed_reason":""` +
 		`},` +
 		`"relationships":{` +
 		`"user":{` +

--- a/controllers/api_v1/keyword_test.go
+++ b/controllers/api_v1/keyword_test.go
@@ -150,32 +150,31 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordWithValidParams() {
 	if err != nil {
 		log.Error(err)
 	}
+	var parsedRespBody map[string]api_helper.DataResponseObject
+	err = json.Unmarshal(respBodyData, &parsedRespBody)
+	if err != nil {
+		log.Error(err)
+	}
 
-	expectedResp := `{` +
-		`"data":{` +
-		`"id":"1",` +
-		`"type":"keyword",` +
-		`"attributes":{` +
-		`"keyword":"testKeyword",` +
-		`"status":"pending",` +
-		`"links_count":1,` +
-		`"non_adwords_count":1,` +
-		`"non_adword_links":null,` +
-		`"top_position_adwords_count":1,` +
-		`"top_position_adword_links":null,` +
-		`"total_adwords_count":1,` +
-		`"html_code":"testHTML",` +
-		`"failed_reason":""` +
-		`},` +
-		`"relationships":{` +
-		`"user":{` +
-		`"data":{` +
-		fmt.Sprintf(`"id":"%v",`, fmt.Sprint(s.user.ID)) +
-		`"type":"user"` +
-		`}}}}}`
+	data := parsedRespBody["data"]
+	attributes, _ := parsedRespBody["data"].Attributes.(map[string]interface{})
+	relationships := parsedRespBody["data"].Relationships
 
 	assert.Equal(s.T(), http.StatusOK, resp.Code)
-	assert.Equal(s.T(), expectedResp, string(respBodyData))
+	assert.Equal(s.T(), data.ID, "1")
+	assert.Equal(s.T(), data.Type, "keyword")
+	assert.Equal(s.T(), attributes["keyword"], "testKeyword")
+	assert.Equal(s.T(), attributes["status"], "pending")
+	assert.Equal(s.T(), attributes["links_count"], float64(1))
+	assert.Equal(s.T(), attributes["non_adwords_count"], float64(1))
+	assert.Equal(s.T(), attributes["non_adword_links"], nil)
+	assert.Equal(s.T(), attributes["top_position_adwords_count"], float64(1))
+	assert.Equal(s.T(), attributes["top_position_adword_links"], nil)
+	assert.Equal(s.T(), attributes["total_adwords_count"], float64(1))
+	assert.Equal(s.T(), attributes["html_code"], "testHTML")
+	assert.Equal(s.T(), attributes["failed_reason"], "")
+	assert.Equal(s.T(), relationships["user"].Data.Type, "user")
+	assert.Equal(s.T(), relationships["user"].Data.ID, fmt.Sprint(s.user.ID))
 }
 
 func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordWithInvalidKeywordID() {

--- a/controllers/api_v1/keyword_test.go
+++ b/controllers/api_v1/keyword_test.go
@@ -146,7 +146,10 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordWithValidParams() {
 	headers.Set("Authorization", "Bearer test-access")
 
 	resp := testHttp.PerformRequest(s.engine, "GET", "/api/v1/keywords/1", headers, nil)
-	respBodyData, _ := ioutil.ReadAll(resp.Body)
+	respBodyData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+	}
 
 	expectedResp := `{` +
 		`"data":{` +
@@ -191,9 +194,15 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordWithInvalidKeywordID()
 	headers.Set("Authorization", "Bearer test-access")
 
 	resp := testHttp.PerformRequest(s.engine, "GET", "/api/v1/keywords/9999", headers, nil)
-	respBodyData, _ := ioutil.ReadAll(resp.Body)
+	respBodyData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+	}
 	var parsedRespBody map[string][]api_helper.ErrorResponseObject
-	_ = json.Unmarshal(respBodyData, &parsedRespBody)
+	err = json.Unmarshal(respBodyData, &parsedRespBody)
+	if err != nil {
+		log.Error(err)
+	}
 
 	assert.Equal(s.T(), http.StatusNotFound, resp.Code)
 	assert.Equal(s.T(), "keyword not found", parsedRespBody["errors"][0].Detail)
@@ -208,10 +217,13 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordWithValidParamsButNotT
 		Refresh:   "test-refresh",
 	}
 
-	data, _ := json.Marshal(&oauth_test.TokenData{
+	data, err := json.Marshal(&oauth_test.TokenData{
 		Access: tokenItem.Access,
 		UserID: "invalidUserID",
 	})
+	if err != nil {
+		log.Error(err)
+	}
 	tokenItem.Data = data
 
 	db.GetDB().Exec("INSERT INTO oauth2_tokens(created_at, expires_at, code, access, refresh, data) VALUES(?, ?, ?, ?, ?, ?)",
@@ -241,9 +253,15 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordWithValidParamsButNotT
 	headers.Set("Authorization", "Bearer test-not-resource-owner")
 
 	resp := testHttp.PerformRequest(s.engine, "GET", "/api/v1/keywords/1", headers, nil)
-	respBodyData, _ := ioutil.ReadAll(resp.Body)
+	respBodyData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+	}
 	var parsedRespBody map[string][]api_helper.ErrorResponseObject
-	_ = json.Unmarshal(respBodyData, &parsedRespBody)
+	err = json.Unmarshal(respBodyData, &parsedRespBody)
+	if err != nil {
+		log.Error(err)
+	}
 
 	assert.Equal(s.T(), http.StatusNotFound, resp.Code)
 	assert.Equal(s.T(), "keyword not found", parsedRespBody["errors"][0].Detail)
@@ -251,9 +269,15 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordWithValidParamsButNotT
 
 func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordAPIWithoutAuthorizationHeader() {
 	resp := testHttp.PerformRequest(s.engine, "GET", "/api/v1/keywords/1", nil, nil)
-	respBodyData, _ := ioutil.ReadAll(resp.Body)
+	respBodyData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+	}
 	var parsedRespBody map[string][]api_helper.ErrorResponseObject
-	_ = json.Unmarshal(respBodyData, &parsedRespBody)
+	err = json.Unmarshal(respBodyData, &parsedRespBody)
+	if err != nil {
+		log.Error(err)
+	}
 
 	assert.Equal(s.T(), http.StatusUnauthorized, resp.Code)
 	assert.Equal(s.T(), errors.ErrInvalidAccessToken.Error(), parsedRespBody["errors"][0].Detail)
@@ -264,9 +288,15 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordAPIWithInvalidAccessTo
 	headers.Set("Authorization", "invalid_token")
 
 	resp := testHttp.PerformRequest(s.engine, "GET", "/api/v1/keywords/1", headers, nil)
-	respBodyData, _ := ioutil.ReadAll(resp.Body)
+	respBodyData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+	}
 	var parsedRespBody map[string][]api_helper.ErrorResponseObject
-	_ = json.Unmarshal(respBodyData, &parsedRespBody)
+	err = json.Unmarshal(respBodyData, &parsedRespBody)
+	if err != nil {
+		log.Error(err)
+	}
 
 	assert.Equal(s.T(), http.StatusUnauthorized, resp.Code)
 	assert.Equal(s.T(), errors.ErrInvalidAccessToken.Error(), parsedRespBody["errors"][0].Detail)
@@ -283,10 +313,13 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordAPIWithExpiredAccessTo
 		Refresh:   "test-refresh",
 	}
 
-	data, _ := json.Marshal(&oauth_test.TokenData{
+	data, err := json.Marshal(&oauth_test.TokenData{
 		AccessExpiresIn: 1,
 		Access:          tokenItem.Access,
 	})
+	if err != nil {
+		log.Error(err)
+	}
 	tokenItem.Data = data
 
 	db.GetDB().Exec("INSERT INTO oauth2_tokens(created_at, expires_at, code, access, refresh, data) VALUES(?, ?, ?, ?, ?, ?)",
@@ -302,9 +335,15 @@ func (s *KeywordAPIControllerDbTestSuite) TestFetchKeywordAPIWithExpiredAccessTo
 	headers.Set("Authorization", "Bearer test-access")
 
 	resp := testHttp.PerformRequest(s.engine, "GET", "/api/v1/keywords/1", headers, nil)
-	respBodyData, _ := ioutil.ReadAll(resp.Body)
+	respBodyData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+	}
 	var parsedRespBody map[string][]api_helper.ErrorResponseObject
-	_ = json.Unmarshal(respBodyData, &parsedRespBody)
+	err = json.Unmarshal(respBodyData, &parsedRespBody)
+	if err != nil {
+		log.Error(err)
+	}
 
 	assert.Equal(s.T(), http.StatusUnauthorized, resp.Code)
 	assert.Equal(s.T(), errors.ErrExpiredAccessToken.Error(), parsedRespBody["errors"][0].Detail)

--- a/helpers/error_handler/error_message.go
+++ b/helpers/error_handler/error_message.go
@@ -13,7 +13,7 @@ const (
 	emailFormatError        = "invalid email format"
 	emailDuplicateError     = "email already exists"
 	invalidInputError       = "invalid input"
-	keywordNotFoundError    = "keyword not found"
+	KeywordNotFoundError    = "keyword not found"
 	minError                = "%s must be longer than %s"
 	passwordEqError         = "passwords do not match"
 	requiredError           = "%s is required"
@@ -62,7 +62,7 @@ func DatabaseErrorMessage(err error) error {
 	} else {
 		switch err {
 		case gorm.ErrRecordNotFound:
-			return errors.New(keywordNotFoundError)
+			return errors.New(KeywordNotFoundError)
 		}
 		return errors.New(somethingWentWrongError)
 	}

--- a/serializers/keyword_serializer.go
+++ b/serializers/keyword_serializer.go
@@ -1,0 +1,62 @@
+package serializers
+
+import (
+	"fmt"
+
+	"github.com/gutakk/go-google-scraper/helpers/api_helper"
+	"github.com/gutakk/go-google-scraper/models"
+
+	"gorm.io/datatypes"
+)
+
+type KeywordSerializer struct {
+	Keyword models.Keyword
+}
+
+type KeywordJSONResponse struct {
+	Keyword                 string               `json:"keyword"`
+	Status                  models.KeywordStatus `json:"status"`
+	LinksCount              int                  `json:"links_count"`
+	NonAdwordsCount         int                  `json:"non_adwords_count"`
+	NonAdwordLinks          datatypes.JSON       `json:"non_adword_links"`
+	TopPositionAdwordsCount int                  `json:"top_position_adwords_count"`
+	TopPositionAdwordLinks  datatypes.JSON       `json:"top_position_adword_links"`
+	TotalAdwordsCount       int                  `json:"total_adwords_count"`
+	HtmlCode                string               `json:"html_code"`
+	FailedReason            string               `json:"failed_reason"`
+}
+
+func (k *KeywordSerializer) JSONAPIFormat() api_helper.DataResponse {
+	if k.Keyword.Model == nil {
+		return api_helper.DataResponse{}
+	}
+
+	formattedKeyword := KeywordJSONResponse{
+		Keyword:                 k.Keyword.Keyword,
+		Status:                  k.Keyword.Status,
+		LinksCount:              k.Keyword.LinksCount,
+		NonAdwordsCount:         k.Keyword.NonAdwordsCount,
+		NonAdwordLinks:          k.Keyword.NonAdwordLinks,
+		TopPositionAdwordsCount: k.Keyword.TopPositionAdwordsCount,
+		TopPositionAdwordLinks:  k.Keyword.TopPositionAdwordLinks,
+		TotalAdwordsCount:       k.Keyword.TotalAdwordsCount,
+		HtmlCode:                k.Keyword.HtmlCode,
+		FailedReason:            k.Keyword.FailedReason,
+	}
+
+	relationships := api_helper.RelationshipsObject{
+		ID:   fmt.Sprint(k.Keyword.UserID),
+		Type: models.UserType,
+	}
+
+	dataResponse := api_helper.DataResponse{
+		Data: api_helper.DataResponseObject{
+			ID:            fmt.Sprint(k.Keyword.ID),
+			Type:          models.KeywordType,
+			Attributes:    formattedKeyword,
+			Relationships: relationships.JSONAPIFormat(),
+		},
+	}
+
+	return dataResponse
+}

--- a/serializers/keyword_serializer_test.go
+++ b/serializers/keyword_serializer_test.go
@@ -1,0 +1,71 @@
+package serializers_test
+
+import (
+	"testing"
+
+	"github.com/gutakk/go-google-scraper/helpers/api_helper"
+	"github.com/gutakk/go-google-scraper/models"
+	"github.com/gutakk/go-google-scraper/serializers"
+
+	"gopkg.in/go-playground/assert.v1"
+	"gorm.io/gorm"
+)
+
+func TestJSONAPIFormatKeywordResponseWithValidKeyword(t *testing.T) {
+	keyword := models.Keyword{
+		Model:                   &gorm.Model{ID: 1},
+		Keyword:                 "testKeyword1",
+		Status:                  models.Pending,
+		LinksCount:              1,
+		NonAdwordsCount:         1,
+		NonAdwordLinks:          []byte("testNonAdwordLinks"),
+		TopPositionAdwordsCount: 1,
+		TopPositionAdwordLinks:  []byte("testTopPositionAdwordLinks"),
+		TotalAdwordsCount:       1,
+		UserID:                  1,
+		HtmlCode:                "testHTML",
+		FailedReason:            "",
+		User:                    &models.User{},
+	}
+
+	keywordSerializer := serializers.KeywordSerializer{Keyword: keyword}
+	result := keywordSerializer.JSONAPIFormat()
+
+	relationships := make(map[string]api_helper.RelationshipsResponse)
+	relationships["user"] = api_helper.RelationshipsResponse{
+		Data: api_helper.RelationshipsObject{
+			ID:   "1",
+			Type: "user",
+		},
+	}
+
+	expected := api_helper.DataResponse{
+		Data: api_helper.DataResponseObject{
+			ID:   "1",
+			Type: "keyword",
+			Attributes: serializers.KeywordJSONResponse{
+				Keyword:                 "testKeyword1",
+				Status:                  models.Pending,
+				LinksCount:              1,
+				NonAdwordsCount:         1,
+				NonAdwordLinks:          []byte("testNonAdwordLinks"),
+				TopPositionAdwordsCount: 1,
+				TopPositionAdwordLinks:  []byte("testTopPositionAdwordLinks"),
+				TotalAdwordsCount:       1,
+				HtmlCode:                "testHTML",
+				FailedReason:            "",
+			},
+			Relationships: relationships,
+		},
+	}
+
+	assert.Equal(t, expected, result)
+}
+
+func TestJSONAPIFormatKeywordResponseWithBlankKeyword(t *testing.T) {
+	keyword := models.Keyword{}
+	keywordSerializer := serializers.KeywordSerializer{Keyword: keyword}
+	result := keywordSerializer.JSONAPIFormat()
+
+	assert.Equal(t, api_helper.DataResponse{Data: api_helper.DataResponseObject{}}, result)
+}

--- a/serializers/keywords_serializer.go
+++ b/serializers/keywords_serializer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gutakk/go-google-scraper/helpers/api_helper"
 	"github.com/gutakk/go-google-scraper/models"
+
 	"gorm.io/datatypes"
 )
 


### PR DESCRIPTION
## What happened
Resolve #16 

## Insight
- [x] Add fetch keyword result API

## Proof Of Work
- Fetch keyword result API
```http
# Request
curl --location --request GET 'localhost:8080/api/v1/keywords/1' \
--header 'Authorization: Bearer OTE3OTK3YTATZWVJOS0ZNDG5LWFMODCTZWI2YZA3ODE0OTFH'

# Response
200 OK
{
    "data": {
        "id": "1",
        "type": "keyword",
        "attributes": {
            "keyword": "AWS",
            "status": "processed",
            "links_count": 147,
            "non_adwords_count": 9,
            "non_adword_links": [
                "https://aws.amazon.com/th/",
                "https://aws.amazon.com/th/what-is-aws/",
                "https://aws.amazon.com/th/products/",
                "https://aws.amazon.com/th/pricing/",
                "https://aws.amazon.com/th/free/",
                "https://en.wikipedia.org/wiki/Amazon_Web_Services",
                "https://www.blognone.com/topics/aws",
                "https://www.linkedin.com/company/amazon-web-services",
                "https://reinvent.awsevents.com/"
            ],
            "top_position_adwords_count": 3,
            "top_position_adword_links": [
                "https://aws.amazon.com/free/",
                "https://www.salesforce.com/ap/form/sem/crm-service-demos_b-ph/?bc=OTH",
                "https://activity.huaweicloud.com/intl/en-us/free_packages/"
            ],
            "total_adwords_count": 3,
            "html_code": "test"
        },
        "relationships": {
            "user": {
                "data": {
                    "id": "2",
                    "type": "user"
                }
            }
        }
    }
}
```

- Fetch result with invalid keyword id
```http
# Request
curl --location --request GET 'localhost:8080/api/v1/keywords/999' \
--header 'Authorization: Bearer OTE3OTK3YTATZWVJOS0ZNDG5LWFMODCTZWI2YZA3ODE0OTFH'

# Response
404 Not Found
{
    "errors": [
        {
            "detail": "keyword not found",
            "status": 404
        }
    ]
}
```

- Fetch result with invalid user
```http
# Request
curl --location --request GET 'localhost:8080/api/v1/keywords/1' \
--header 'Authorization: Bearer OTBIMZQYMDATNTU3YY0ZNZIWLTLJZDCTMJNHMJLIYJKYYWFJ'

# Response
404 Not Found
{
    "errors": [
        {
            "detail": "keyword not found",
            "status": 404
        }
    ]
}
```