### PR TITLE
Fix cannot redirect to register page

### DIFF
--- a/controllers/keyword_test.go
+++ b/controllers/keyword_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bxcodec/faker/v3"
-	"github.com/gin-gonic/gin"
 	"github.com/gutakk/go-google-scraper/config"
 	"github.com/gutakk/go-google-scraper/db"
 	"github.com/gutakk/go-google-scraper/models"
@@ -18,6 +16,9 @@ import (
 	testFile "github.com/gutakk/go-google-scraper/tests/file"
 	"github.com/gutakk/go-google-scraper/tests/fixture"
 	testHttp "github.com/gutakk/go-google-scraper/tests/http"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/go-playground/assert.v1"
@@ -67,42 +68,36 @@ func TestKeywordDbTestSuite(t *testing.T) {
 	suite.Run(t, new(KeywordDbTestSuite))
 }
 
-func TestDisplayKeywordWithAuthenticatedUserWithoutFilter(t *testing.T) {
-	engine := testConfig.GetRouter(true)
-	new(KeywordController).applyRoutes(EnsureAuthenticatedUserGroup(engine))
-
+func (s *KeywordDbTestSuite) TestDisplayKeywordWithAuthenticatedUserWithoutFilter() {
 	// Cookie from login API Set-Cookie header
 	headers := http.Header{}
-	cookie := fixture.GenerateCookie("user_id", "test-user")
+	cookie := fixture.GenerateCookie("user_id", s.userID)
 	headers.Set("Cookie", cookie.Name+"="+cookie.Value)
 
-	response := testHttp.PerformRequest(engine, "GET", "/keyword", headers, nil)
+	response := testHttp.PerformRequest(s.engine, "GET", "/keyword", headers, nil)
 	p, err := ioutil.ReadAll(response.Body)
 	isKeywordPage := err == nil && strings.Index(string(p), "<title>Keyword</title>") > 0
 
-	assert.Equal(t, http.StatusOK, response.Code)
-	assert.Equal(t, true, isKeywordPage)
+	assert.Equal(s.T(), http.StatusOK, response.Code)
+	assert.Equal(s.T(), true, isKeywordPage)
 }
 
-func TestDisplayKeywordWithAuthenticatedUserWithFilter(t *testing.T) {
-	engine := testConfig.GetRouter(true)
-	new(KeywordController).applyRoutes(EnsureAuthenticatedUserGroup(engine))
-
+func (s *KeywordDbTestSuite) TestDisplayKeywordWithAuthenticatedUserWithFilter() {
 	// Cookie from login API Set-Cookie header
 	headers := http.Header{}
-	cookie := fixture.GenerateCookie("user_id", "test-user")
+	cookie := fixture.GenerateCookie("user_id", s.userID)
 	headers.Set("Cookie", cookie.Name+"="+cookie.Value)
 
 	url := "/keyword?" +
 		"filter[keyword]=Test&" +
 		"filter[url]=Test" +
 		"filter[is_adword_advertiser]=Test"
-	response := testHttp.PerformRequest(engine, "GET", url, headers, nil)
+	response := testHttp.PerformRequest(s.engine, "GET", url, headers, nil)
 	p, err := ioutil.ReadAll(response.Body)
 	isKeywordPage := err == nil && strings.Index(string(p), "<title>Keyword</title>") > 0
 
-	assert.Equal(t, http.StatusOK, response.Code)
-	assert.Equal(t, true, isKeywordPage)
+	assert.Equal(s.T(), http.StatusOK, response.Code)
+	assert.Equal(s.T(), true, isKeywordPage)
 }
 
 func TestDisplayKeywordWithGuestUser(t *testing.T) {

--- a/controllers/keyword_test.go
+++ b/controllers/keyword_test.go
@@ -115,6 +115,17 @@ func TestDisplayKeywordWithGuestUser(t *testing.T) {
 	assert.Equal(t, "/login", response.Header().Get("Location"))
 }
 
+func (s *KeywordDbTestSuite) TestDisplayKeywordWithUserIDCookieButNoUser() {
+	cookie := fixture.GenerateCookie("user_id", "test-user")
+	headers := http.Header{}
+	headers.Set("Cookie", cookie.Name+"="+cookie.Value)
+
+	response := testHttp.PerformRequest(s.engine, "GET", "/keyword", headers, nil)
+
+	assert.Equal(s.T(), http.StatusFound, response.Code)
+	assert.Equal(s.T(), "/login", response.Header().Get("Location"))
+}
+
 func (s *KeywordDbTestSuite) TestDisplayKeywordResultWithAuthenticatedUserAndValidKeyword() {
 	keyword := models.Keyword{UserID: s.userID, Keyword: faker.Name()}
 	db.GetDB().Create(&keyword)

--- a/controllers/login_test.go
+++ b/controllers/login_test.go
@@ -7,14 +7,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bxcodec/faker/v3"
-	"github.com/gin-gonic/gin"
 	"github.com/gutakk/go-google-scraper/db"
 	"github.com/gutakk/go-google-scraper/models"
 	testConfig "github.com/gutakk/go-google-scraper/tests/config"
 	testDB "github.com/gutakk/go-google-scraper/tests/db"
 	"github.com/gutakk/go-google-scraper/tests/fixture"
 	testHttp "github.com/gutakk/go-google-scraper/tests/http"
+
+	"github.com/bxcodec/faker/v3"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/go-playground/assert.v1"
@@ -72,7 +73,10 @@ func (s *LoginDbTestSuite) TestLoginWithValidParameters() {
 }
 
 func (s *LoginDbTestSuite) TestDisplayLoginWithAuthenticatedUser() {
-	cookie := fixture.GenerateCookie("user_id", "test-user")
+	user := models.User{}
+	_ = db.GetDB().First(&user)
+
+	cookie := fixture.GenerateCookie("user_id", user.ID)
 	s.headers.Set("Cookie", cookie.Name+"="+cookie.Value)
 
 	response := testHttp.PerformRequest(s.engine, "GET", "/login", s.headers, nil)

--- a/controllers/login_test.go
+++ b/controllers/login_test.go
@@ -170,5 +170,5 @@ func (s *LoginDbTestSuite) TestDisplayLoginWithUserIDCookieButNoUser() {
 	pageOK := err == nil && strings.Index(string(p), "<title>Login</title>") > 0
 
 	assert.Equal(s.T(), http.StatusOK, response.Code)
-	assert.Equal(s.T(), true, pageOK)
+	assert.Equal(s.T(), true, pageOK) // TODO: Check the controller in other task
 }

--- a/controllers/login_test.go
+++ b/controllers/login_test.go
@@ -166,7 +166,9 @@ func (s *LoginDbTestSuite) TestDisplayLoginWithUserIDCookieButNoUser() {
 	headers.Set("Cookie", cookie.Name+"="+cookie.Value)
 
 	response := testHttp.PerformRequest(s.engine, "GET", "/login", headers, nil)
+	p, err := ioutil.ReadAll(response.Body)
+	pageOK := err == nil && strings.Index(string(p), "<title>Login</title>") > 0
 
-	assert.Equal(s.T(), http.StatusFound, response.Code)
-	assert.Equal(s.T(), "/login", response.Header().Get("Location"))
+	assert.Equal(s.T(), http.StatusOK, response.Code)
+	assert.Equal(s.T(), true, pageOK)
 }

--- a/controllers/login_test.go
+++ b/controllers/login_test.go
@@ -155,3 +155,14 @@ func TestDisplayLogin(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.Code)
 	assert.Equal(t, true, pageOK)
 }
+
+func (s *LoginDbTestSuite) TestDisplayLoginWithUserIDCookieButNoUser() {
+	cookie := fixture.GenerateCookie("user_id", "test-user")
+	headers := http.Header{}
+	headers.Set("Cookie", cookie.Name+"="+cookie.Value)
+
+	response := testHttp.PerformRequest(s.engine, "GET", "/login", headers, nil)
+
+	assert.Equal(s.T(), http.StatusFound, response.Code)
+	assert.Equal(s.T(), "/login", response.Header().Get("Location"))
+}

--- a/controllers/logout_test.go
+++ b/controllers/logout_test.go
@@ -1,14 +1,19 @@
 package controllers
 
 import (
+	"log"
 	"net/http"
 	"testing"
 
-	"github.com/gin-gonic/gin"
+	"github.com/gutakk/go-google-scraper/db"
+	"github.com/gutakk/go-google-scraper/models"
 	testConfig "github.com/gutakk/go-google-scraper/tests/config"
 	"github.com/gutakk/go-google-scraper/tests/fixture"
 	testHttp "github.com/gutakk/go-google-scraper/tests/http"
+
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/go-playground/assert.v1"
 )
 
@@ -27,7 +32,14 @@ func TestLogoutTestSuit(t *testing.T) {
 }
 
 func (s *LogoutTestSuite) TestLogoutWithAuthenticatedUser() {
-	cookie := fixture.GenerateCookie("user_id", "test-user")
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte("testPassword"), bcrypt.DefaultCost)
+	if err != nil {
+		log.Fatalf("Cannot hash password: %s", err)
+	}
+	user := models.User{Email: "test@email.com", Password: string(hashedPassword)}
+	db.GetDB().Create(&user)
+
+	cookie := fixture.GenerateCookie("user_id", user.ID)
 	headers := http.Header{}
 	headers.Set("Cookie", cookie.Name+"="+cookie.Value)
 

--- a/controllers/register_test.go
+++ b/controllers/register_test.go
@@ -157,7 +157,9 @@ func (s *RegisterDbTestSuite) TestDisplayRegisterWithUserIDCookieButNoUser() {
 	headers.Set("Cookie", cookie.Name+"="+cookie.Value)
 
 	response := testHttp.PerformRequest(s.engine, "GET", "/register", headers, nil)
+	p, err := ioutil.ReadAll(response.Body)
+	pageOK := err == nil && strings.Index(string(p), "<title>Register</title>") > 0
 
-	assert.Equal(s.T(), http.StatusFound, response.Code)
-	assert.Equal(s.T(), "/register", response.Header().Get("Location"))
+	assert.Equal(s.T(), http.StatusOK, response.Code)
+	assert.Equal(s.T(), true, pageOK)
 }

--- a/controllers/register_test.go
+++ b/controllers/register_test.go
@@ -140,3 +140,14 @@ func TestDisplayRegister(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.Code)
 	assert.Equal(t, true, pageOK)
 }
+
+func (s *RegisterDbTestSuite) TestDisplayRegisterWithUserIDCookieButNoUser() {
+	cookie := fixture.GenerateCookie("user_id", "test-user")
+	headers := http.Header{}
+	headers.Set("Cookie", cookie.Name+"="+cookie.Value)
+
+	response := testHttp.PerformRequest(s.engine, "GET", "/register", headers, nil)
+
+	assert.Equal(s.T(), http.StatusFound, response.Code)
+	assert.Equal(s.T(), "/register", response.Header().Get("Location"))
+}

--- a/controllers/register_test.go
+++ b/controllers/register_test.go
@@ -161,5 +161,5 @@ func (s *RegisterDbTestSuite) TestDisplayRegisterWithUserIDCookieButNoUser() {
 	pageOK := err == nil && strings.Index(string(p), "<title>Register</title>") > 0
 
 	assert.Equal(s.T(), http.StatusOK, response.Code)
-	assert.Equal(s.T(), true, pageOK)
+	assert.Equal(s.T(), true, pageOK) // TODO: Check the controller in other task
 }

--- a/middlewares/ensure_authenticated_user.go
+++ b/middlewares/ensure_authenticated_user.go
@@ -4,28 +4,16 @@ import (
 	"net/http"
 
 	session "github.com/gutakk/go-google-scraper/helpers/session"
-	"github.com/gutakk/go-google-scraper/models"
 
 	"github.com/gin-gonic/gin"
 )
 
 func EnsureAuthenticatedUser(c *gin.Context) {
-	userID := session.Get(c, "user_id")
+	userID := c.MustGet("currentUser")
 
 	if userID == nil {
-		redirectToLogin(c)
-	} else {
-		_, err := models.FindUserByID(userID)
-
-		if err != nil {
-			session.Delete(c, "user_id")
-			redirectToLogin(c)
-		}
+		session.AddFlash(c, "Login required", "error")
+		c.Redirect(http.StatusFound, "/login")
+		c.Abort()
 	}
-}
-
-func redirectToLogin(c *gin.Context) {
-	session.AddFlash(c, "Login required", "error")
-	c.Redirect(http.StatusFound, "/login")
-	c.Abort()
 }

--- a/middlewares/ensure_authenticated_user.go
+++ b/middlewares/ensure_authenticated_user.go
@@ -3,8 +3,10 @@ package middlewares
 import (
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	session "github.com/gutakk/go-google-scraper/helpers/session"
+	"github.com/gutakk/go-google-scraper/models"
+
+	"github.com/gin-gonic/gin"
 )
 
 func EnsureAuthenticatedUser(c *gin.Context) {
@@ -14,5 +16,15 @@ func EnsureAuthenticatedUser(c *gin.Context) {
 		session.AddFlash(c, "Login required", "error")
 		c.Redirect(http.StatusFound, "/login")
 		c.Abort()
+	} else {
+		var err error
+		_, err = models.FindUserByID(userID)
+
+		if err != nil {
+			session.Delete(c, "user_id")
+			session.AddFlash(c, "Login required", "error")
+			c.Redirect(http.StatusFound, "/login")
+			c.Abort()
+		}
 	}
 }

--- a/middlewares/ensure_authenticated_user.go
+++ b/middlewares/ensure_authenticated_user.go
@@ -13,18 +13,19 @@ func EnsureAuthenticatedUser(c *gin.Context) {
 	userID := session.Get(c, "user_id")
 
 	if userID == nil {
-		session.AddFlash(c, "Login required", "error")
-		c.Redirect(http.StatusFound, "/login")
-		c.Abort()
+		redirectToLogin(c)
 	} else {
-		var err error
-		_, err = models.FindUserByID(userID)
+		_, err := models.FindUserByID(userID)
 
 		if err != nil {
 			session.Delete(c, "user_id")
-			session.AddFlash(c, "Login required", "error")
-			c.Redirect(http.StatusFound, "/login")
-			c.Abort()
+			redirectToLogin(c)
 		}
 	}
+}
+
+func redirectToLogin(c *gin.Context) {
+	session.AddFlash(c, "Login required", "error")
+	c.Redirect(http.StatusFound, "/login")
+	c.Abort()
 }

--- a/middlewares/ensure_guest_user.go
+++ b/middlewares/ensure_guest_user.go
@@ -3,15 +3,26 @@ package middlewares
 import (
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	session "github.com/gutakk/go-google-scraper/helpers/session"
+	"github.com/gutakk/go-google-scraper/models"
+
+	"github.com/gin-gonic/gin"
 )
 
 func EnsureGuestUser(c *gin.Context) {
 	userID := session.Get(c, "user_id")
 
 	if userID != nil {
-		c.Redirect(http.StatusFound, "/")
-		c.Abort()
+		var err error
+		_, err = models.FindUserByID(userID)
+
+		if err != nil {
+			session.Delete(c, "user_id")
+			c.Redirect(http.StatusFound, c.FullPath())
+			c.Abort()
+		} else {
+			c.Redirect(http.StatusFound, "/")
+			c.Abort()
+		}
 	}
 }

--- a/middlewares/ensure_guest_user.go
+++ b/middlewares/ensure_guest_user.go
@@ -3,25 +3,14 @@ package middlewares
 import (
 	"net/http"
 
-	session "github.com/gutakk/go-google-scraper/helpers/session"
-	"github.com/gutakk/go-google-scraper/models"
-
 	"github.com/gin-gonic/gin"
 )
 
 func EnsureGuestUser(c *gin.Context) {
-	userID := session.Get(c, "user_id")
+	userID := c.MustGet("currentUser")
 
 	if userID != nil {
-		_, err := models.FindUserByID(userID)
-
-		if err != nil {
-			session.Delete(c, "user_id")
-			c.Redirect(http.StatusFound, c.FullPath())
-		} else {
-			c.Redirect(http.StatusFound, "/")
-		}
-
+		c.Redirect(http.StatusFound, "/")
 		c.Abort()
 	}
 }

--- a/middlewares/ensure_guest_user.go
+++ b/middlewares/ensure_guest_user.go
@@ -13,16 +13,15 @@ func EnsureGuestUser(c *gin.Context) {
 	userID := session.Get(c, "user_id")
 
 	if userID != nil {
-		var err error
-		_, err = models.FindUserByID(userID)
+		_, err := models.FindUserByID(userID)
 
 		if err != nil {
 			session.Delete(c, "user_id")
 			c.Redirect(http.StatusFound, c.FullPath())
-			c.Abort()
 		} else {
 			c.Redirect(http.StatusFound, "/")
-			c.Abort()
 		}
+
+		c.Abort()
 	}
 }


### PR DESCRIPTION
## What happened
### Issue
@carryall found that she cannot access to register page, app keep redirect to the root path.
I found that because I check only for if userID cookie exist in the browser but not in the database then user cannot access to auth feature and able to access to authenticated app feature. So I updated middleware to check if userID cookie also exist in the database.

Resolve #74 

## Insight
- [x] Update ensure guest and authenticated user middleware to check user id in the cookie with database
- [x] Add test cases for this bug

## Proof Of Work
Fixed the problem described in `What Happened`